### PR TITLE
Compatibility with k8s 1.16

### DIFF
--- a/transmission/templates/psp.yaml
+++ b/transmission/templates/psp.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "..fullname" . }}


### PR DESCRIPTION
Hello, thank you for the Chart!

When deploying into a 1.17 cluster I have the following error :
`Error: unable to build kubernetes objects from release manifest: unable to recognize "": no matches for kind "PodSecurityPolicy" in version "extensions/v1beta1"
`

API group extensions/v1beta1 is not valid anymore for PSPs, see https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/